### PR TITLE
SEGV at Menu#createItem()

### DIFF
--- a/src/org/eclipse/swt/widgets/Menu.d
+++ b/src/org/eclipse/swt/widgets/Menu.d
@@ -507,7 +507,7 @@ void createItem (MenuItem item, int index) {
             */
             auto hHeap = OS.GetProcessHeap ();
             StringT buffer = StrToTCHARs (0, " \0");
-            int byteCount = (buffer.length-1) * TCHAR.sizeof;
+            int byteCount = buffer.length * TCHAR.sizeof;
             auto pszText = cast(TCHAR*) OS.HeapAlloc (hHeap, OS.HEAP_ZERO_MEMORY, byteCount);
             OS.MoveMemory (pszText, buffer.ptr, byteCount);
             MENUITEMINFO info;


### PR DESCRIPTION
This is code at Menu.java (of SWT):

``` Java
TCHAR buffer = new TCHAR (0, " ", true);
int byteCount = buffer.length () * TCHAR.sizeof;
```

If TCHAR class constructed by `terminate = true`, it will make space of '\0'. 
Therefore, buffer.length() is 2. 

``` D
StringT buffer = StrToTCHARs (0, " \0");
int byteCount = (buffer.length-1) * TCHAR.sizeof;
```

`buffer.length-1` of this code must be `buffer.length`. (buffer.length is 2)

An error occur occasionally in an environment of low on memory.
