### PR TITLE
For2067linux

### DIFF
--- a/src/org/eclipse/swt/internal/Lock.d
+++ b/src/org/eclipse/swt/internal/Lock.d
@@ -18,7 +18,7 @@ version(Tango){
     import tango.core.sync.Mutex;
     import tango.core.sync.Condition;
 } else {
-    import core.sync.mutex;
+    import java.nonstandard.sync.mutex;
     import java.nonstandard.sync.condition;
 }
 

--- a/src/org/eclipse/swt/widgets/RunnableLock.d
+++ b/src/org/eclipse/swt/widgets/RunnableLock.d
@@ -19,7 +19,7 @@ version(Tango){
     import tango.core.sync.Mutex;
 } else { // Phobos
     import java.nonstandard.sync.condition;
-    import core.sync.mutex;
+    import java.nonstandard.sync.mutex;
 }
 
 /**


### PR DESCRIPTION
Changes `core.sync.mutex` to `java.nonstandard.sync.mutex`.

See also: https://github.com/d-widget-toolkit/base/pull/19